### PR TITLE
Don't attempt to authenticate with universal links if a callback isn't provided

### DIFF
--- a/FSOAuth.m
+++ b/FSOAuth.m
@@ -80,7 +80,7 @@
     
     NSURL *authURL = nil;
     
-    if (universalLinksSupported) {
+    if (universalLinksSupported && hasUniversalCallback) {
         NSString *urlEncodedCallbackString = nil;
         if (hasUniversalCallback) {
             urlEncodedCallbackString = [self urlEncodedStringForString:universalURICallbackString];


### PR DESCRIPTION
This makes it so that folks who don't want to or can't support universal links in iOS 9 gracefully fall back to the existing auth flow.